### PR TITLE
Adicionando E-Com Club

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ _Curitiba/PR_
 
 # E
 
+[E-Com Club](https://github.com/ecomclub)    
+Vue, Vuex, VueRouter, Antdv, Bootstrap, Netlify, NodeJS, Mongo, ElasticSearch, Redis     
+_Belo Horizonte/MG_
+
 [EBANX](https://ebanx.com)    
 Vue, VueRouter, VueMC, Ruby on Rails, Docker     
 _Curitiba/PR_


### PR DESCRIPTION
Usamos Vue.js pra maioria dos projetos aqui :smile: 

Achei que fazia sentido linkar a org no GitHub em vez do institucional da empresa, mas não vi isto em nenhuma outra então se for um problema eu posso alterar.

Valeu!