### PR TITLE
Adicionando checkbox para filtro de trabalho Remoto

### DIFF
--- a/src/Main.vue
+++ b/src/Main.vue
@@ -6,10 +6,11 @@ import AppTagFilter from './components/AppTagFilter'
 import LoadingBar from './components/LoadingBar'
 import AppFilter from './components/AppFilter'
 import LetterRow from './components/LetterRow'
+import AppCheckbox from './components/AppCheckbox'
 
 export default {
   name: 'AppMain',
-  components: { LetterRow, AppTagFilter, AppFilter, LoadingBar },
+  components: { LetterRow, AppTagFilter, AppFilter, LoadingBar, AppCheckbox },
   data: () => ({
     loading: true,
     tagsSelecteds: Object.freeze([]),
@@ -19,11 +20,16 @@ export default {
     filters: {
       tags: Object.freeze([]),
       name: '',
-      location: ''
+      location: '',
+      remote: false
     }
   }),
   computed: {
     hasFilter () {
+      if (this.filters.remote) {
+        return true
+      }
+
       return Object.values(this.filters)
         .some(negate(isEmpty))
     },
@@ -70,6 +76,10 @@ export default {
       )
 
       this.loading = false
+    },
+    onFilterRemote () {
+      window.scrollTo(0, 0)
+      this.filters.remote = true
     }
   },
   async mounted () {
@@ -121,13 +131,22 @@ export default {
               placeholder="Encontre uma empresa local"
               v-model="filters.location" />
           </div>
+          <div class="column is-2">
+            <AppCheckbox
+              id="remote"
+              label="Remoto?"
+              v-model="filters.remote"
+            />
+          </div>
         </div>
         <div>
           <LoadingBar v-if="loading" />
           <LetterRow
             v-for="group in groups"
             :key="group.letter"
-            v-bind="group"/>
+            v-bind="group"
+            @filter-remote="onFilterRemote"
+          />
         </div>
       </main>
     </div>

--- a/src/Main.vue
+++ b/src/Main.vue
@@ -118,7 +118,7 @@ export default {
           :tags="meta.tags" />
       </div>
       <main class="column is-three-quarters">
-        <div class="columns is-mobile">
+        <div class="columns">
           <div class="column">
             <AppFilter
               label="Nome da empresa"
@@ -131,7 +131,7 @@ export default {
               placeholder="Encontre uma empresa local"
               v-model="filters.location" />
           </div>
-          <div class="column is-2">
+          <div class="column is-2 checkbox-column">
             <AppCheckbox
               id="remote"
               label="Remoto?"
@@ -152,3 +152,10 @@ export default {
     </div>
   </div>
 </template>
+
+<style scoped>
+.checkbox-column {
+  display: flex;
+  align-items: center;
+}
+</style>

--- a/src/Root.vue
+++ b/src/Root.vue
@@ -12,7 +12,7 @@
 import AppFooter from './components/AppFooter'
 import AppHero from './components/AppHero'
 
-const AppMain = () => import(/* webpackChunkName: "app-main" */'./Main')
+const AppMain = () => import(/* webpackChunkName: "app-main" */'./Main.vue')
 
 export default {
   name: 'app',

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -1,7 +1,4 @@
-$primary: #40b882;
-$link: #304455;
-$dark: #35495e;
-$gap: 22px;
+@import "./variables.scss";
 
 @import "bulma/sass/utilities/_all.sass";
 @import "bulma/sass/base/_all.sass";

--- a/src/assets/scss/main.scss
+++ b/src/assets/scss/main.scss
@@ -22,4 +22,5 @@ $gap: 22px;
 html, body {
   width: 100%;
   height: 100%;
+  scroll-behavior: smooth;
 }

--- a/src/assets/scss/variables.scss
+++ b/src/assets/scss/variables.scss
@@ -1,0 +1,5 @@
+$primary: #40b882;
+$link: #304455;
+$dark: #35495e;
+$gap: 22px;
+$tablet: 769px;

--- a/src/components/AppCheckbox.vue
+++ b/src/components/AppCheckbox.vue
@@ -1,0 +1,38 @@
+<script>
+export default {
+  name: 'AppCheckbox',
+  props: {
+    value: Boolean,
+    label: String,
+    id: [String, Number]
+  },
+  computed: {
+    computedValue: {
+      get () {
+        return this.newValue
+      },
+      set (value) {
+        this.newValue = value
+        this.$emit('input', value)
+      }
+    }
+  }
+}
+</script>
+
+<template>
+  <div class="app-checkbox">
+    <label class="app-checkbox-label" :for="id"> {{ label }} </label>
+
+    <input
+      :id="id"
+      class="app-checkbox-input"
+      type="checkbox"
+      v-model="computedValue"
+    />
+  </div>
+</template>
+
+<style>
+
+</style>

--- a/src/components/AppCheckbox.vue
+++ b/src/components/AppCheckbox.vue
@@ -9,7 +9,7 @@ export default {
   computed: {
     computedValue: {
       get () {
-        return this.newValue
+        return this.value
       },
       set (value) {
         this.newValue = value
@@ -21,18 +21,64 @@ export default {
 </script>
 
 <template>
-  <div class="app-checkbox">
-    <label class="app-checkbox-label" :for="id"> {{ label }} </label>
-
+  <label :for="id" class="app-checkbox">
     <input
       :id="id"
       class="app-checkbox-input"
       type="checkbox"
       v-model="computedValue"
+      :checked="computedValue"
     />
-  </div>
+
+    <span class="app-checkbox-check" />
+    <span class="app-checkbox-label">{{ label }}</span>
+  </label>
 </template>
 
-<style>
+<style lang="scss">
+@import "../assets/scss/variables.scss";
 
+/* inspired by Buefy checkbox style */
+.app-checkbox {
+  position: relative;
+  width: 100%;
+  display: flex;
+  margin-top: 15px;
+  line-height: 1.25;
+  cursor: pointer;
+}
+
+.app-checkbox-input {
+  position: absolute;
+  left: 0;
+  opacity: 0;
+  outline: none;
+  z-index: -1;
+}
+
+.app-checkbox-check {
+  display: block;
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
+  border-radius: 4px;
+  border: 2px solid #7a7a7a;
+  transition: background .15s ease-out;
+  background: transparent;
+}
+
+.app-checkbox-input:checked + .app-checkbox-check {
+  background: #35495e url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'%3E%3Cpath d='M.04.627L.146.52.43.804.323.91zm.177.177L.854.167.96.273.323.91z' fill='%23fff'/%3E%3C/svg%3E") no-repeat 50%;
+  border-color: #35495e;
+}
+
+.app-checkbox-label {
+  margin-left: 5px;
+}
+
+@media screen and (max-width: $tablet) {
+  .app-checkbox {
+    margin: 0;
+  }
+}
 </style>

--- a/src/components/AppFilter.vue
+++ b/src/components/AppFilter.vue
@@ -32,6 +32,8 @@ export default {
 </template>
 
 <style lang="scss" scoped>
+@import "../assets/scss/variables.scss";
+
 .app-filter {
   margin-top: 5px;
   margin-bottom: 10px;
@@ -40,6 +42,12 @@ export default {
     font-size: 0.75em;
     letter-spacing: 0.1em;
     text-transform: uppercase;
+  }
+}
+
+@media screen and (max-width: $tablet) {
+  .app-filter {
+    margin: 0;
   }
 }
 </style>

--- a/src/components/CompanyRow.vue
+++ b/src/components/CompanyRow.vue
@@ -16,6 +16,11 @@ export default {
     id () {
       return `company-${this.slug}`
     }
+  },
+  methods: {
+    setFilterRemote () {
+      this.$emit('filter-remote')
+    }
   }
 }
 </script>
@@ -32,7 +37,9 @@ export default {
         v-if="company.remote"
         src="../assets/icon-remote.svg"
         title="Suporte a trabalho remoto"
-        alt="Suporte a trabalho remoto"/>
+        alt="Suporte a trabalho remoto"
+        @click="setFilterRemote"
+      />
     </h3>
 
     <div class="tags are-medium">
@@ -56,13 +63,11 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-
 .icon-remote {
   width: 20px;
   height: 20px;
   display: block;
   float: right;
-
+  cursor: pointer;
 }
-
 </style>

--- a/src/components/LetterRow.vue
+++ b/src/components/LetterRow.vue
@@ -15,6 +15,11 @@ export default {
     id () {
       return `letter-${this.letter}`
     }
+  },
+  methods: {
+    onFilterRemote () {
+      this.$emit('filter-remote')
+    }
   }
 }
 </script>
@@ -33,7 +38,9 @@ export default {
       class="panel-block"
       v-for="(company, index) in companies"
       :key="letter + '-' + index"
-      v-bind="{ company }"/>
+      v-bind="{ company }"
+      @filter-remote="onFilterRemote"
+    />
   </section>
 </template>
 

--- a/src/lib/companies/filter.js
+++ b/src/lib/companies/filter.js
@@ -48,13 +48,24 @@ const filterByName = async (name, companies) => {
   })
 }
 
+const filterByRemote = async (remote, companies) => {
+  if (remote) {
+    return filter(companies, company => {
+      return company.remote
+    })
+  }
+
+  return companies
+}
+
 const filterCompanies = (rules, companies) => {
-  const { tags, name, location } = rules
+  const { tags, name, location, remote } = rules
 
   return pWaterfall([
     result => onIdle(() => filterByTags(tags, result)),
     result => onIdle(() => filterByName(name, result)),
     result => onIdle(() => filterByLocation(location, result)),
+    result => onIdle(() => filterByRemote(remote, result)),
     result => Object.freeze(result)
   ], companies)
 }


### PR DESCRIPTION
Este PR implementa uma forma de filtrar a listagem de empresas por trabalho remoto. O filtro é possível de duas maneiras:

1. Com a checkbox ao lado da localização
2. Quando se clica no ícone que destaca que uma empresa aceita trabalho remoto

O estilo do checkbox segue o implementado pela [equipe do Buefy](https://github.com/buefy/buefy/tree/dev/src/components/checkbox)