### PR TITLE
Adiciona empresa FacilitaPay

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,10 @@ _Bauru/SP_
 Vue, Vuex, Nuxt, Axios, Vue-router, Laravel  
 _Joinville/SC_  
 
+[FacilitaPay](https://www.facilitapay.com/)
+Vue, Node, Elixir, Vue-router, Vuetify, DigitalOcean, Docker
+_Nova Lima/MS_
+
 [Facilite](https://facilite.online)  
 Firebase    
 _Jaraguá do Sul/SC_


### PR DESCRIPTION
Adiciona empresa [FacilitaPay](https://facilitapay.com/) à lista de empresas que usam Vue no Brasil.